### PR TITLE
Add keepalive Flask server

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import threading
 from datetime import datetime, timedelta
 
 from aiogram import Bot, Dispatcher, F, types
@@ -16,8 +17,20 @@ import keyboards
 import rus_calendar as cal
 from aiogram_calendar import simple_calendar
 import messages
+from flask import Flask
 
 logging.basicConfig(level=logging.INFO)
+
+app = Flask(__name__)
+
+
+@app.get('/')
+def home() -> str:
+    return 'Бот живой, не трожь.'
+
+
+def run_flask() -> None:
+    app.run(host='0.0.0.0', port=10000)
 
 # Токен бота хранится напрямую в коде. Не использовать env для простоты демонстрации.
 BOT_TOKEN = "7355813660:AAFE6dOJMaHuCMVCRXC6M8gen4ZlamnbZmM"
@@ -550,4 +563,5 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
+    threading.Thread(target=run_flask, daemon=True).start()
     asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiogram>=3
 python-dotenv
 aiogram-calendar
+Flask


### PR DESCRIPTION
## Summary
- spin up a minimal Flask server on port 10000
- start it in a background thread during bot startup
- include Flask in requirements

## Testing
- `pytest -q`
- `python -m py_compile main.py utils.py db.py calendar_utils.py rus_calendar.py activity_log.py keyboards.py messages.py`
- `pip install -q -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_686d2567738c8326aa4f373dd076709b