### PR TITLE
Add keep-alive server for Replit

### DIFF
--- a/keep_alive.py
+++ b/keep_alive.py
@@ -1,0 +1,15 @@
+from flask import Flask
+from threading import Thread
+
+app = Flask('')
+
+@app.route('/')
+def home():
+    return "I'm alive"
+
+def run():
+    app.run(host='0.0.0.0', port=8080)
+
+def keep_alive():
+    t = Thread(target=run)
+    t.start()

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-import threading
 from datetime import datetime, timedelta
 
 from aiogram import Bot, Dispatcher, F, types
@@ -17,20 +16,9 @@ import keyboards
 import rus_calendar as cal
 from aiogram_calendar import simple_calendar
 import messages
-from flask import Flask
+from keep_alive import keep_alive
 
 logging.basicConfig(level=logging.INFO)
-
-app = Flask(__name__)
-
-
-@app.get('/')
-def home() -> str:
-    return 'Бот живой, не трожь.'
-
-
-def run_flask() -> None:
-    app.run(host='0.0.0.0', port=10000)
 
 # Токен бота хранится напрямую в коде. Не использовать env для простоты демонстрации.
 BOT_TOKEN = "7355813660:AAFE6dOJMaHuCMVCRXC6M8gen4ZlamnbZmM"
@@ -563,5 +551,5 @@ async def main() -> None:
 
 
 if __name__ == '__main__':
-    threading.Thread(target=run_flask, daemon=True).start()
+    keep_alive()
     asyncio.run(main())


### PR DESCRIPTION
## Summary
- keep the bot alive on free Replit using a small Flask server
- import and start the keep-alive server from `main.py`
- remove the old Flask code

## Testing
- `python -m py_compile main.py keep_alive.py`


------
https://chatgpt.com/codex/tasks/task_e_686f7d88a1408326a28acb0137de2c5a